### PR TITLE
Allows load_dot_env to parse empty .env

### DIFF
--- a/R/dotenv-package.r
+++ b/R/dotenv-package.r
@@ -90,6 +90,10 @@ load_dot_env <- function(file = ".env") {
   tmp <- readLines(file)
   tmp <- ignore_comments(tmp)
   tmp <- ignore_empty_lines(tmp)
+
+  # If there's no env vars, return nothing
+  if (length(tmp) == 0) return(invisible())
+
   tmp <- lapply(tmp, parse_dot_line)
   set_env(tmp)
 }


### PR DESCRIPTION
Should close #5. Let me know if this make sense, otherwise I can adapt.