### PR TITLE
add recursive search to load_dot_env

### DIFF
--- a/R/dotenv-package.r
+++ b/R/dotenv-package.r
@@ -137,7 +137,7 @@ load_dot_env <- function(file = ".env", recursive = FALSE) {
   tmp <- ignore_comments(tmp)
   tmp <- ignore_empty_lines(tmp)
   
-  # If no environment variables are found, return invisibly
+  # If there's no env vars, return nothing
   if (length(tmp) == 0) return(invisible())
   
   # Parse and set environment variables from the .env file


### PR DESCRIPTION
Added functionality to recursively search parent directories for an .env file.  Users can opt-in to this by setting recursive = TRUE.  If recursive = TRUE, then load_dot_env will search the directory, and if no .env file is found, parent directories are searched until one is found.